### PR TITLE
feat: アカウント有効化機能の実装

### DIFF
--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,14 @@
+class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      flash[:success] = 'アカウントが有効になりました！'
+      redirect_to user
+    else
+      flash[:danger] = '有効化リンクの期限が切れています。'
+      redirect_to root_url
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,9 +4,16 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])
-      log_in user
-      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      redirect_back_or user
+      if user.activated?
+        log_in user
+        params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+        redirect_back_or user
+      else
+        message = 'このアカウントは有効化されていません。'
+        message += 'メールの有効化リンクからアクセスしてください。'
+        flash[:warning] = message
+        redirect_to root_url
+      end
     else
       flash.now[:danger] = 'メールアドレスとパスワードの組み合わせが正しくありません'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,12 @@ class UsersController < ApplicationController
   before_action :admin_user, only: :destroy
 
   def index
-    @pagy, @users = pagy(User.all)
+    @pagy, @users = pagy(User.where(activated: true))
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated
   end
 
   def new
@@ -20,9 +21,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:success] = 'KEIKOBAへようこそ！'
-      redirect_to @user
+      @user.send_activation_email
+      flash[:info] = 'アカウントが作成されました！このアカウントを有効にするメールを送信しましたので、ご確認ください。'
+      redirect_to root_url
     else
       render 'new'
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,7 +17,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user&.authenticated?(cookies[:remember_token])
+      if user&.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,17 @@
+class UserMailer < ApplicationMailer
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: 'アカウントの有効化'
+  end
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = 'Hi'
+
+    mail to: 'to@example.org'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
+  attr_accessor :remember_token, :activation_token
 
-  before_save { self.email = email.downcase }
+  before_save :downcase_email
+  before_create :create_activation_digest
   validates :name, presence: true, length: { in: 4..50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
@@ -29,14 +30,38 @@ class User < ApplicationRecord
   end
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
 
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   # ユーザーのログイン情報を破棄する
   def forget
     update_attribute(:remember_digest, nil)
+  end
+
+  # アカウントを有効にする
+  def activate
+    update_columns(activated: true, activated_at: Time.zone.now)
+  end
+
+  # 有効化用のメールを送信する
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
+  private
+
+  # メールアドレスを全て小文字にする
+  def downcase_email
+    self.email = email.downcase
+  end
+
+  # 有効化トークンとダイジェストを作成および代入する
+  def create_activation_digest
+    self.activation_token = User.new_token
+    self.activation_digest = User.digest(activation_token)
   end
 end

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,13 @@
+<h1>KEIKOBA</h1>
+
+<p><%= @user.name %> さん、こんにちは！</p>
+
+<p>
+KEIKOBA へのご登録ありがとうございます。<br>
+アカウントを有効にするには、下記ボタンをクリックしてください。
+</p>
+
+<button style="background-color: #2B9CFD; border-radius: 30px; border: none;" onmouseover="this.style.backgroundColor='#278DD8'"
+onmouseout="this.style.backgroundColor='#2B9CFD'">
+  <%= link_to "アカウントを有効にする", edit_account_activation_url(@user.activation_token, email: @user.email), style: "text-decoration: none; color: white;" %>
+</button>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,6 @@
+<%= @user.name %> さん、こんにちは！
+
+KEIKOBA へのご登録ありがとうございます。
+アカウントを有効にするには、下記リンクをクリックしてください。
+
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,10 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  host = 'localhost:3000' # ローカル環境
+  # localhostで開発している場合は以下をお使いください
+  config.action_mailer.default_url_options = { host: host, protocl: 'http' }
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,18 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'blooming-forest-86635.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :port           =>  ENV['MAILGUN_SMTP_PORT'],
+    :address        =>  ENV['MAILGUN_SMTP_SERVER'],
+    :user_name      =>  ENV['MAILGUN_SMTP_LOGIN'],
+    :password       =>  ENV['MAILGUN_SMTP_PASSWORD'],
+    :domain         =>  host,
+    :authentication =>  :plain,
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   get 'users/guest'
   get 'users/following'
   get 'users/followers'
-  get 'sessions/new'
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
-  delete 'logout', to: 'sessions#destroy'  
+  delete 'logout', to: 'sessions#destroy'
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20210514055726_change_activated_of_users.rb
+++ b/db/migrate/20210514055726_change_activated_of_users.rb
@@ -1,0 +1,9 @@
+class ChangeActivatedOfUsers < ActiveRecord::Migration[6.0]
+  def up
+    change_column :users, :activated, :boolean, default: false
+  end
+
+  def down
+    change_column :users, :activated, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_123339) do
+ActiveRecord::Schema.define(version: 2021_05_14_055726) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2021_05_13_123339) do
     t.boolean "admin", default: false
     t.boolean "guest"
     t.string "activation_digest"
-    t.boolean "activated"
+    t.boolean "activated", default: false
     t.datetime "activated_at"
     t.string "reset_digest"
     t.datetime "reset_sent_at"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,9 @@ User.create!(name:  "Example User",
   email: "example@railstutorial.org",
   password:              "foobar",
   password_confirmation: "foobar",
-  admin: true)
+  admin: true,
+  activated: true,
+  activated_at: Time.zone.now)
 
 # 追加のユーザーをまとめて生成する
 99.times do |n|
@@ -13,5 +15,7 @@ password = "password"
 User.create!(name:  name,
     email: email,
     password:              password,
-    password_confirmation: password)
+    password_confirmation: password,
+    activated: true,
+    activated_at: Time.zone.now)
 end

--- a/spec/controllers/account_activations_controller_spec.rb
+++ b/spec/controllers/account_activations_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe AccountActivationsController, type: :controller do
+end

--- a/spec/fixtures/user_mailer/account_activation
+++ b/spec/fixtures/user_mailer/account_activation
@@ -1,0 +1,3 @@
+UserMailer#account_activation
+
+Hi, find me in app/views/user_mailer/account_activation

--- a/spec/fixtures/user_mailer/password_reset
+++ b/spec/fixtures/user_mailer/password_reset
@@ -1,0 +1,3 @@
+UserMailer#password_reset
+
+Hi, find me in app/views/user_mailer/password_reset

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,14 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe UserMailer, type: :mailer do
+  describe 'account_activation' do
+    let(:mail) { UserMailer.account_activation }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Account activation')
+      expect(mail.to).to eq(['to@example.org'])
+      expect(mail.from).to eq(['from@example.com'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('Hi')
+    end
+  end
+
+  describe 'password_reset' do
+    let(:mail) { UserMailer.password_reset }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Password reset')
+      expect(mail.to).to eq(['to@example.org'])
+      expect(mail.from).to eq(['from@example.com'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('Hi')
+    end
+  end
+end


### PR DESCRIPTION
アカウントを有効化する機能を実装しました。

アカウント有効化の段取りは下記の通り。
１　Userの初期状態はunactivated
２　Userを新規登録した時、有効化tokenと有効化digestを生成
３　有効化digestをデータベースに保存し、有効化tokenを有効化用リンクと共にUserにメールする
４　Userが有効化用リンクをクリックしたら、アプリはメールアドレスをキーにしてUserを探し、データベース内に保存された有効化digestと比較することで有効化tokenを認証する
５　Userを認証できたら、Userをactivatedにする