### PR TITLE
change_adimin_of_usersファイルを、元のコードに変更。

### DIFF
--- a/db/migrate/20210513123339_change_admin_of_users.rb
+++ b/db/migrate/20210513123339_change_admin_of_users.rb
@@ -1,11 +1,9 @@
 class ChangeAdminOfUsers < ActiveRecord::Migration[6.0]
   def up
-    change_index :favorites, [:post_id], unique: true
-    change_index :favorites, [:user_id], unique: true
+    change_column :users, :admin, :boolean, default: false
   end
 
   def down 
-    change_index :favorites, [:post_id]
-    change_index :favorites, [:user_id]
+    change_column :users, :admin, :boolean
   end
 end


### PR DESCRIPTION
Herokuでエラーが発生した原因を調査した。
どうやら、マイグレーションファイルのchange_admin_of_usersファイルを、以前のプルリク時に書き換えてしまったのが原因のようだ。
そのため、過去のプルリクを参照し、該当コードを復旧させた。

<エラー内容>
undefined method `change_index' for #<ChangeAdminOfUsers:0x0000565468c4ca80>