### PR TITLE
fix: Userのnameのlength範囲を3..50に広げた。

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   before_save :downcase_email
   before_create :create_activation_digest
-  validates :name, presence: true, length: { in: 4..50 }
+  validates :name, presence: true, length: { in: 3..50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX },


### PR DESCRIPTION
[Issue #23](https://github.com/glaciermelt00/keikoba_app/issues/23)で出たエラーに対する修正コード。

<修正内容>
Userモデルname属性のvalidatesで、当初length範囲を4..50としていた。
おそらく、日本語の漢字氏名は空白文字を入れるとminimum 3文字なので、length範囲を3..50に変更した。