### PR TITLE
feat: style: 記事の編集・更新機能を実装。

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   before_action :logged_in_user, only: %i[new create destroy]
   before_action :correct_user, only: :destroy
+  before_action :set_post, only: %i[show edit update]
 
   def new
     @post = current_user.posts.build
@@ -17,8 +18,17 @@ class PostsController < ApplicationController
     end
   end
 
-  def show
-    @post = Post.find(params[:id])
+  def show; end
+
+  def edit; end
+
+  def update
+    if @post.update(post_params)
+      flash[:success] = '記事を更新しました！'
+      redirect_to @post
+    else
+      render 'edit'
+    end
   end
 
   def destroy
@@ -37,5 +47,10 @@ class PostsController < ApplicationController
   def correct_user
     @post = current_user.posts.find_by(id: params[:id])
     redirect_to root_url if @post.nil?
+  end
+
+  # show/edit/updateで@postを事前に仕込んでおく（リファクタリング）
+  def set_post
+    @post = Post.find(params[:id])
   end
 end

--- a/app/views/posts/_post_header.html.erb
+++ b/app/views/posts/_post_header.html.erb
@@ -4,9 +4,11 @@
       <div class="col-8">
         <h2><%= @post.name %></h2>
       </div>
-      <div class="col-4">
-        <button type="button" class="btn btn-primary">編集する</button>
-      </div>
+      <% if @post.user_id == current_user.id %>
+        <div class="col-4">
+          <%= link_to "編集する", edit_post_path(@post), class: "btn btn-primary" %>
+        </div>
+      <% end %>
     </div>
     <div class="row mt-3">
       <div class="col-12">

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,91 @@
+<% provide(:title, '記事編集') %>
+<div class="container">
+  <div class="py-5 text-center">
+    <h2>記事編集</h2>
+  </div>
+  <div class="row g-3">
+    <div class="col-10 offset-1">
+      <%= form_with(model:@post, local: true) do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+        <div class="row g-3">
+
+          <div class="col-12">
+            <%= f.label :name, '名称', class: 'form-label' %>
+            <%= f.text_field :name, class: "form-control" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :images, '画像アップロード', class: 'form-label' %>
+            <%= f.file_field :images, accept: "image/jpeg, image/gif, image/png", class: "form-control" %>
+          </div>
+
+          <%
+=begin%>
+ <div class="col-md-6">
+            <label for="zip" class="form-label">郵便番号</label>
+            <input type="text" class="form-control" id="zip" placeholder="" required="">
+          </div>
+
+          <div class="col-md-6">
+            <label for="state" class="form-label">都道府県</label>
+            <select class="form-select" id="state" required="">
+              <option value="">選択してください</option>
+              <option>東京都</option>
+            </select>
+          </div> 
+<%
+=end%>
+
+          <div class="col-12">
+            <%= f.label :address, '住所', class: "form-label" %>
+            <%= f.text_field :address, class: "form-control", placeholder: "東京都千代田区千代田1-1" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :fee, '料金', class: 'form-label' %>
+            <%= f.text_field :fee, class: "form-control" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :available_time, '時間帯', class: 'form-label' %>
+            <%= f.text_field :available_time, class: "form-control" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :holiday, '定休日', class: 'form-label' %>
+            <%= f.text_field :holiday, class: "form-control" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :phone_number, '電話番号', class: 'form-label' %>
+            <%= f.text_field :phone_number, class: "form-control" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :url, 'URL', class: 'form-label' %>
+            <%= f.text_field :url, class: "form-control" %>
+          </div>
+
+          <div class="col-12">
+            <%= f.label :content, '備考', class: 'form-label' %>
+            <%= f.text_area :content, class: "form-control" %>
+          </div>
+
+        </div>
+
+        <%= f.submit '更新する', class: "w-100 btn btn-primary btn-lg mt-5" %>
+
+      <% end %>
+    </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+  $("#post_images").bind("change", function() {
+    var size_in_megabytes = this.files[0].size/1024/1024;
+    if (size_in_megabytes > 5) {
+      alert('画像のサイズが5MBを超えています。5MB未満の画像を選択して下さい。');
+      $("#post_images").val("");
+    }
+  });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   end
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
-  resources :posts, only: [:new, :create, :show, :destroy] do
+  resources :posts do
     resource :favorites, only: [:create, :destroy]
     resource :bookmarks, only: [:create, :destroy]
   end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe BookmarksController, type: :controller do
-
 end


### PR DESCRIPTION
<変更点>
- ルーティング
　- postsリソースからonlyオプションを外した（未実装：　index）
- コントローラ
　- Postコントローラ
　　- beforeフィルター：　how/edit/updateアクション実行前にset_postメソッドで@postインスタンスを読み込み
　　- updateアクション追加
- ビュー
　- Post editビュー新規作成（Post newビューをベースに作成）
- その他
　- リファクタリング
　　- Postヘッダー：　自分が投稿した記事の場合のみ、編集ボタンが出るようにする
　- Spec：　rubocopで空行削除