### PR TITLE
test: refactor: モデルスペックのリファクタリング。

### DIFF
--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,13 +1,11 @@
 FactoryBot.define do
   factory :post do
-    sequence(:name)       { |n| "test#{n}@example.com" }
-    user_id               { 1 }
+    sequence(:name)       { |n| "Dojo ##{n}" }
     sequence(:created_at) { |n| n.days.ago }
-  end
+    association :user
 
-  factory :most_recent_post, class: Post do
-    name        { 'test@example.com' }
-    user_id     { 1 }
-    created_at  { Time.zone.now }
+    factory :most_recent_post do
+      created_at  { Time.zone.now }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,20 +1,12 @@
 FactoryBot.define do
   factory :user do
     name                  { '山田 太郎' }
-    email                 { 't-yamada@example.com' }
+    sequence(:email)      { |n| "tester#{n}@example.com" }
     password              { 'password' }
     password_confirmation { 'password' }
-    admin                 { true }
-    activated             { true }
-    activated_at          { Time.zone.now }
-  end
 
-  factory :another_user, class: User do
-    name                  { '上野 花子' }
-    email                 { 'h-ueno@example.com' }
-    password              { 'password' }
-    password_confirmation { 'password' }
-    activated             { true }
-    activated_at          { Time.zone.now }
+    trait :do_remember do
+      after(:create) { |user| user.remember }
+    end
   end
 end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Bookmark, type: :model do
   before(:each) do
-    @user = FactoryBot.create(:user)
-    @another_user = FactoryBot.create(:another_user)
-    @post = FactoryBot.create(:post)
+    @post = create(:post)
+    @another_user = create(:user)
     @bookmark = Bookmark.new(user_id: @another_user.id, post_id: @post.id)
   end
 

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Favorite, type: :model do
   before(:each) do
-    @user = FactoryBot.create(:user)
-    @another_user = FactoryBot.create(:another_user)
-    @post = FactoryBot.create(:post)
+    @post = create(:post)
+    @another_user = create(:user)
     @favorite = Favorite.new(user_id: @another_user.id, post_id: @post.id)
   end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,18 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  before(:each) do
-    @user = FactoryBot.create(:user)
-    @post = FactoryBot.build(:post)
-  end
-
   # name, user_idがあれば、有効な状態であること
   it 'is valid with a name and user_id' do
+    @post = create(:post)
     expect(@post).to be_valid
   end
 
   # user_idがnilなら、無効な状態であること
   it 'is invalid without user_id' do
+    @post = create(:post)
     @post.user_id = nil
     @post.valid?
     expect(@post.errors[:user_id]).to include("を入力してください")
@@ -20,23 +17,23 @@ RSpec.describe Post, type: :model do
 
   # nameが空白なら、無効な状態であること
   it 'is invalid with a blank name' do
-    @post.name = ' '
+    @post = build(:post, name: ' ')
     @post.valid?
     expect(@post.errors[:name]).to include("を入力してください")
   end
 
   # postはcreated_atの降順で並んでいる
   it 'is sorted in descending order by created_at' do
-    @most_recent_post = FactoryBot.create(:most_recent_post)
-    FactoryBot.create_list(:post, 3)
+    @most_recent_post = create(:most_recent_post)
+    create_list(:post, 3)
     expect(@most_recent_post).to eq Post.first
   end
 
   # postが削除されたとき
   context 'if post is deleted' do
     before do
-      @another_user = FactoryBot.create(:another_user)
-      @post.save
+      @post = create(:post)
+      @another_user = create(:user)
     end
     # 関連付けられたFavoriteが削除される
     it 'associated favorite is deleted' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,33 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  before(:each) do
-    @user = build(:user)
-  end
-
   # name, email, passwordがあれば、有効な状態であること
   it 'is valid with a name, email, and password' do
+    @user = build(:user)
     expect(@user).to be_valid
   end
 
   describe 'name' do
     # nameが空白なら、無効な状態であること
     it 'is invalid with a blank name' do
-      @user.name = '   '
+      @user = build(:user, name: '  ')
       @user.valid?
       expect(@user.errors[:name]).to include("を入力してください")
     end
 
     # nameが3文字未満なら、無効な状態であること
     it 'is invalid with a name less than 3 characters' do
-      @user.name = 'a' * 2
+      @user = build(:user, name: 'a' * 2)
       @user.valid?
       expect(@user.errors[:name]).to include("は3文字以上で入力してください")
     end
 
     # nameが50文字を超えるなら、無効な状態であること
     it 'is invalid for a name more than 50 characters' do
-      @user.name = 'a' * 51
+      @user = build(:user, name: 'a' * 51)
       @user.valid?
       expect(@user.errors[:name]).to include("は50文字以内で入力してください")
     end
@@ -36,20 +33,21 @@ RSpec.describe User, type: :model do
   describe 'email' do
     # emailが空白なら、無効な状態であること
     it 'is invalid with a blank email' do
-      @user.email = '   '
+      @user = build(:user, email: '   ')
       @user.valid?
       expect(@user.errors[:email]).to include("を入力してください")
     end
 
     # emailが255文字を超えると、無効な状態であること
     it 'is invalid for a email more than 255 characters' do
-      @user.email = format('%s@example.com', ('a' * 244))
+      @user = build(:user, email: format('%s@example.com', ('a' * 244)))
       @user.valid?
       expect(@user.errors[:email]).to include("は255文字以内で入力してください")
     end
 
     # フォーマットに合致するemailなら、有効な状態であること
     it 'is valid with an email that matches the format ' do
+      @user = build(:user)
       valid_addresses = %w[user@example.com USER@foo.COM A_US-ER@foo.bar.org first.last@foo.jp alice+bob@baz.cn]
       valid_addresses.each do |valid_address|
         @user.email = valid_address
@@ -59,6 +57,7 @@ RSpec.describe User, type: :model do
 
     # フォーマットに合致しないemailなら、無効な状態であること
     it 'is invalid with an email that does not match the format' do
+      @user = build(:user)
       invalid_addresses = %w[user@example,com user_at_foo.org user.name@example. foo@bar_baz.com foo@bar+baz.com foo@bar..com]
       invalid_addresses.each do |invalid_address|
         @user.email = invalid_address
@@ -69,8 +68,8 @@ RSpec.describe User, type: :model do
 
     # 重複したemailなら、無効な状態であること
     it 'is invalid with a duplicate email ' do
+      @user = create(:user)
       duplicate_user = @user.dup
-      @user.save
       duplicate_user.valid?
       expect(duplicate_user.errors[:email]).to include("はすでに存在します")
     end
@@ -78,92 +77,81 @@ RSpec.describe User, type: :model do
     # DBに保存されたemailは小文字であること
     it 'makes email downcase when user is saved to DB' do
       mixed_case_email = 'Foo@ExAMPle.CoM'
-      @user.email = mixed_case_email
-      @user.save
-      expect(mixed_case_email.downcase).to eq @user.reload.email
+      @user = create(:user, email: mixed_case_email)
+      expect(mixed_case_email.downcase).to eq @user.email
     end
   end
 
   # passwordが空白なら、無効な状態であること
   it 'is invalid with a blank password' do
-    @user.password = @user.password_confirmation = ' ' * 6
+    @user = build(:user, password: ' ' * 6, password_confirmation: ' ' * 6)
     @user.valid?
     expect(@user.errors[:password]).to include("を入力してください")
   end
 
   # passwordが6文字未満なら、無効な状態であること
   it 'is invalid for a password less than 6 characters' do
-    @user.password = @user.password_confirmation = 'a' * 5
+    @user = build(:user, password: 'a' * 5, password_confirmation: 'a' * 5)
     @user.valid?
     expect(@user.errors[:password]).to include("は6文字以上で入力してください")
   end
 
   # rememberメソッドを呼び出すと、remember_digestが上書きされる
   it 'updates remember_digest with remember method' do
-    @user.save
-    expect(@user.remember_digest).to be_nil
-    @user.remember
+    @user = create(:user, :do_remember)
     expect(@user.remember_digest).to_not be_nil
   end
 
   # digestが存在し、authenticated?メソッドに適切なtokenを渡すと、trueを返す
   it 'returns true with authenticated? method and appropriate token if digest is present' do
-    @user.save
-    @user.remember
+    @user = create(:user, :do_remember)
     expect(@user.authenticated?(:remember, @user.remember_token)).to be true
   end
 
   # digestがnilなら、authenticated?メソッドはfalseを返す
   it 'returns false with authenticated? method if digest is nil' do
+    @user = build(:user)
     expect(@user.authenticated?(:remember, '')).to be false
   end
 
   # forgetメソッドで、remember_digestがnilになる
   it 'updates remember_digest to nil with forget method' do
-    @user.save
-    @user.remember
-    expect(@user.remember_digest).to_not be_nil
+    @user = create(:user, :do_remember)
     @user.forget
     expect(@user.remember_digest).to be_nil
   end
 
   # activateメソッドで、activatedがtrueに上書きされる
   it 'updates activated to true with activate method' do
-    @user.save
-    @user.toggle!(:activated)
-    expect(@user.activated).to be false
+    @user = create(:user)
     @user.activate
     expect(@user.activated).to be true
   end
 
   # activateメソッドで、activated_atが現在時刻に上書きされる
   it 'updates activated_at to present time with activate method' do
-    @user.save
-    @user.activated_at = nil
-    expect(@user.activated_at).to be_nil
+    @user = create(:user)
     @user.activate
     expect(@user.activated_at).to_not be_nil
   end
 
   # create_reset_digestメソッドで、reset_digestが上書きされる
   it 'updates reset_digest with create_reset_digest method' do
-    @user.save
-    expect(@user.reset_digest).to be_nil
+    @user = create(:user)
     @user.create_reset_digest
     expect(@user.reset_digest).to_not be_nil
   end
 
   # create_reset_digestメソッドで、reset_sent_atが上書きされる
   it 'updates reset_sent_at with create_reset_digest method' do
-    @user.save
-    expect(@user.reset_sent_at).to be_nil
+    @user = create(:user)
     @user.create_reset_digest
     expect(@user.reset_sent_at).to_not be_nil
   end
 
   # reset_sent_atから2時間過ぎたら、password_reset_expired?メソッドはtrueを返す
   it 'returns true with password_reset_expired? method if it takes 2 hours from reset_sent_at' do
-    @user.save
+    @user = create(:user)
     @user.create_reset_digest
     @user.reset_sent_at = 2.hours.ago
     expect(@user.password_reset_expired?).to be true
@@ -171,6 +159,7 @@ RSpec.describe User, type: :model do
 
   # before_createで発生するprivateのcreate_activation_digestで、activation_tokenが作成される
   it 'creates activation_token with privated create_activation_digest method caused by before_create' do
+    @user = build(:user)
     expect(@user.activation_token).to be_nil
     @user.save
     expect(@user.activation_token).to_not be_nil
@@ -178,6 +167,7 @@ RSpec.describe User, type: :model do
 
   # before_createで発生するprivateのcreate_activation_digestで、activation_digestが作成される
   it 'creates activation_digest with privated create_activation_digest method caused by before_create' do
+    @user = build(:user)
     expect(@user.activation_digest).to be_nil
     @user.save
     expect(@user.activation_digest).to_not be_nil
@@ -186,26 +176,25 @@ RSpec.describe User, type: :model do
   # userが削除された場合
   describe 'if user is deleted' do
     before do
-      @user.save
-      @another_user = FactoryBot.create(:another_user)
-      @post = @user.posts.create!(name: 'Lorem ipsum')
+      @post = create(:post)
+      @another_user = create(:user)
     end
 
     # 関連付けられたpostが削除される
     it 'associated post is deleted' do
-      expect { @user.destroy }.to change { Post.count }.from(1).to(0)
+      expect { @post.user.destroy }.to change { Post.count }.from(1).to(0)
     end
 
     # 関連付けられたFavorite_postが削除される
     it 'associated favorite_post is deleted' do
       Favorite.create!(user_id: @another_user.id, post_id: @post.id)
-      expect { @user.destroy }.to change { Favorite.count }.from(1).to(0)
+      expect { @post.user.destroy }.to change { Favorite.count }.from(1).to(0)
     end
 
     # 関連付けられたbookmark_postが削除される
     it 'associated bookmark_post is deleted' do
       Bookmark.create!(user_id: @another_user.id, post_id: @post.id)
-      expect { @user.destroy }.to change { Bookmark.count }.from(1).to(0)
+      expect { @post.user.destroy }.to change { Bookmark.count }.from(1).to(0)
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Users', type: :request do
   before(:each) do
     @user = FactoryBot.create(:user)
-    @another_user = FactoryBot.create(:another_user)
+    @another_user = FactoryBot.create(:user)
   end
 
   describe 'GET /signup' do


### PR DESCRIPTION
<変更点>
-factory：　associationと継承、traitを用いて、シンプルにした
　　　　　　traitを用いた基準は、3回以上出てきたメソッドに限定した（2回未満のメソッドもあるが、traitにはしていない）
-model：　修正したfactoryを元に、シンプルに記載した。
　　　　　　特にpost作成時にassociationでuserも作成されるので、コードを削減できた。
　　　　　　また、できるだけbeforeせず、exampleの中でオブジェクトを作るようにした。
　　　　　　Userモデルは200行とコード量が多いが、26 examples含まれるため7.7行/example。空行・コメント行・it・endを引くと3.7行/exampleのため、妥当と言える。